### PR TITLE
Bug fix for falsy value as inputs

### DIFF
--- a/index.js
+++ b/index.js
@@ -220,7 +220,7 @@ ${spacer.repeat(indent - indentBy)})`;
 
 function generateArg(types, arg, indent, depth, spacer, indentBy, inputVariables) {
     const argValue = getArgValue(types, arg, indent, depth, spacer, indentBy, inputVariables)
-    if (argValue)
+    if (argValue !== null)
         return `${spacer.repeat(indent)}${arg.name}: ${argValue}`;
     return null;
 }
@@ -231,7 +231,7 @@ function getArgValue(types, arg, indent, depth, spacer, indentBy, inputVariables
 
     console.debug(`${' '.repeat(indent + 1)}- getArgValue - ${arg.name}: ${generateTypeValue(arg.type)}`);
     const argVal = generateArgValue(types, argType, indent, depth, spacer, indentBy, inputVariables);
-    if (argVal == "")
+    if (argVal === "")
         return null;
     if (kind == 'LIST')
         if (inputVariables)


### PR DESCRIPTION
or a query like this
`searchConfig(cluster_level = false) {}`

it generates it like
`searchConfig() {}`

which is an invalid syntax.

updated the == as it as
`false == ""`  is true as they both are falsy.

and only returning null if the argValue is null